### PR TITLE
feat: portfolio allocation chart and dividend projection

### DIFF
--- a/app/(app)/portfolio/page.tsx
+++ b/app/(app)/portfolio/page.tsx
@@ -6,6 +6,8 @@ import { Card, CardContent } from "@/components/ui/card"
 import { VariationBadge } from "@/components/ui/variation-badge"
 import { formatCurrency, formatPercent, variationColor } from "@/lib/utils"
 import { AddTransactionDialog } from "@/components/features/portfolio/add-transaction-dialog"
+import { AllocationChart } from "@/components/features/portfolio/allocation-chart"
+import { DividendProjection } from "@/components/features/portfolio/dividend-projection"
 import { TrendingUp, DollarSign, BarChart3, PlusCircle } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
@@ -41,7 +43,7 @@ export default async function PortfolioPage() {
     ticker: string; assetType: string; quantity: number; averagePrice: number;
     currentPrice: number; totalCost: number; currentValue: number;
     gain: number; gainPercent: number; changePercent: number;
-    name: string; logoUrl?: string | null; weight: number;
+    name: string; logoUrl?: string | null; weight: number; dividendsYield?: number | null;
   }> = []
   let summary = { totalValue: 0, totalCost: 0, totalGain: 0, totalGainPercent: 0 }
 
@@ -62,6 +64,7 @@ export default async function PortfolioPage() {
         averagePrice: p.averagePrice, currentPrice, totalCost, currentValue,
         gain, gainPercent, changePercent: quote?.regularMarketChangePercent ?? 0,
         name: quote?.shortName ?? p.ticker, logoUrl: quote?.logourl, weight: 0,
+        dividendsYield: quote?.dividendsYield,
       }
     })
 
@@ -124,6 +127,17 @@ export default async function PortfolioPage() {
                 </Card>
               )
             })}
+          </div>
+
+          {/* Charts */}
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <Card>
+              <CardContent className="p-5">
+                <p className="text-sm font-medium mb-4">Alocação</p>
+                <AllocationChart positions={positions} totalValue={summary.totalValue} />
+              </CardContent>
+            </Card>
+            <DividendProjection positions={positions} />
           </div>
 
           {/* Positions table */}

--- a/components/features/portfolio/allocation-chart.tsx
+++ b/components/features/portfolio/allocation-chart.tsx
@@ -1,0 +1,132 @@
+"use client"
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from "recharts"
+import { formatCurrency } from "@/lib/utils"
+
+interface Position {
+  ticker: string
+  assetType: string
+  currentValue: number
+  weight: number
+}
+
+interface Props {
+  positions: Position[]
+  totalValue: number
+}
+
+const COLORS = [
+  "#3b82f6","#10b981","#f59e0b","#ef4444","#8b5cf6",
+  "#06b6d4","#84cc16","#f97316","#ec4899","#6366f1",
+  "#14b8a6","#eab308","#a855f7","#0ea5e9","#22c55e",
+]
+
+export function AllocationChart({ positions, totalValue }: Props) {
+  // By position (top 8 + others)
+  const sorted = [...positions].sort((a, b) => b.currentValue - a.currentValue)
+  const top8 = sorted.slice(0, 8)
+  const others = sorted.slice(8)
+  const othersValue = others.reduce((s, p) => s + p.currentValue, 0)
+
+  const pieData = [
+    ...top8.map(p => ({ name: p.ticker, value: p.currentValue, weight: p.weight })),
+    ...(othersValue > 0 ? [{ name: "Outros", value: othersValue, weight: (othersValue / totalValue) * 100 }] : []),
+  ]
+
+  // By asset type
+  const typeMap: Record<string, number> = {}
+  positions.forEach(p => {
+    typeMap[p.assetType] = (typeMap[p.assetType] ?? 0) + p.currentValue
+  })
+  const typeData = Object.entries(typeMap).map(([name, value]) => ({
+    name: name === "STOCK" ? "Ações" : name === "FII" ? "FIIs" : name,
+    value,
+    weight: (value / totalValue) * 100,
+  }))
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      {/* By ticker */}
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-3">Por ativo</p>
+        <ResponsiveContainer width="100%" height={220}>
+          <PieChart>
+            <Pie
+              data={pieData}
+              cx="50%"
+              cy="50%"
+              innerRadius={55}
+              outerRadius={90}
+              paddingAngle={2}
+              dataKey="value"
+            >
+              {pieData.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(v) => [formatCurrency(Number(v))]}
+              contentStyle={{ background: "hsl(var(--background))", border: "1px solid hsl(var(--border))" }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+        {/* Legend */}
+        <div className="space-y-1 mt-2">
+          {pieData.map((d, i) => (
+            <div key={d.name} className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-2">
+                <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: COLORS[i % COLORS.length] }} />
+                <span className="font-medium">{d.name}</span>
+              </div>
+              <div className="flex items-center gap-3 tabular-nums">
+                <span className="text-muted-foreground">{formatCurrency(d.value)}</span>
+                <span className="font-semibold w-10 text-right">{d.weight.toFixed(1)}%</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* By type */}
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-3">Por tipo de ativo</p>
+        <ResponsiveContainer width="100%" height={220}>
+          <PieChart>
+            <Pie
+              data={typeData}
+              cx="50%"
+              cy="50%"
+              innerRadius={55}
+              outerRadius={90}
+              paddingAngle={2}
+              dataKey="value"
+              label={({ name, weight }: { name?: string; weight?: number }) => `${name} ${(weight ?? 0).toFixed(0)}%`}
+              labelLine={false}
+            >
+              {typeData.map((_, i) => (
+                <Cell key={i} fill={COLORS[i * 3 % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(v) => [formatCurrency(Number(v))]}
+              contentStyle={{ background: "hsl(var(--background))", border: "1px solid hsl(var(--border))" }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="space-y-1 mt-2">
+          {typeData.map((d, i) => (
+            <div key={d.name} className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-2">
+                <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: COLORS[i * 3 % COLORS.length] }} />
+                <span className="font-medium">{d.name}</span>
+              </div>
+              <div className="flex items-center gap-3 tabular-nums">
+                <span className="text-muted-foreground">{formatCurrency(d.value)}</span>
+                <span className="font-semibold w-10 text-right">{d.weight.toFixed(1)}%</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/portfolio/dividend-projection.tsx
+++ b/components/features/portfolio/dividend-projection.tsx
@@ -1,0 +1,75 @@
+"use client"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { formatCurrency } from "@/lib/utils"
+import { TrendingUp } from "lucide-react"
+
+interface Position {
+  ticker: string
+  currentValue: number
+  dividendsYield?: number | null
+}
+
+interface Props {
+  positions: Position[]
+}
+
+export function DividendProjection({ positions }: Props) {
+  const rows = positions
+    .filter(p => p.dividendsYield && p.dividendsYield > 0)
+    .map(p => ({
+      ticker: p.ticker,
+      currentValue: p.currentValue,
+      annualDY: (p.dividendsYield ?? 0) * 100,
+      monthlyIncome: (p.currentValue * (p.dividendsYield ?? 0)) / 12,
+    }))
+    .sort((a, b) => b.monthlyIncome - a.monthlyIncome)
+
+  const totalMonthly = rows.reduce((s, r) => s + r.monthlyIncome, 0)
+  const totalAnnual = totalMonthly * 12
+
+  if (rows.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-emerald-500" />
+          Projeção de Dividendos
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Summary */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="rounded-lg bg-emerald-500/10 p-4 text-center">
+            <p className="text-xs text-muted-foreground">Renda mensal estimada</p>
+            <p className="text-2xl font-bold text-emerald-500 tabular-nums mt-1">{formatCurrency(totalMonthly)}</p>
+          </div>
+          <div className="rounded-lg bg-blue-500/10 p-4 text-center">
+            <p className="text-xs text-muted-foreground">Renda anual estimada</p>
+            <p className="text-2xl font-bold text-blue-500 tabular-nums mt-1">{formatCurrency(totalAnnual)}</p>
+          </div>
+        </div>
+
+        {/* Per asset */}
+        <div className="space-y-2">
+          {rows.map(r => (
+            <div key={r.ticker} className="flex items-center justify-between text-sm">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold w-16">{r.ticker}</span>
+                <span className="text-xs text-muted-foreground">DY {r.annualDY.toFixed(1)}%</span>
+              </div>
+              <div className="flex items-center gap-4 tabular-nums">
+                <span className="text-muted-foreground text-xs hidden sm:block">{formatCurrency(r.currentValue)}</span>
+                <span className="text-emerald-500 font-medium">{formatCurrency(r.monthlyIncome)}/mês</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          * Projeção baseada no DY dos últimos 12 meses. Não constitui garantia de rendimento futuro.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `AllocationChart`: two donut charts showing allocation by ticker (top 8 + others) and by asset type
- Add `DividendProjection`: card showing estimated monthly/annual passive income based on DY
- Integrate both between summary cards and positions table on the portfolio page

Closes #41, #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)