### PR TITLE
feat: portfolio notes, goal tracking, and CSV import

### DIFF
--- a/app/(app)/portfolio/actions.ts
+++ b/app/(app)/portfolio/actions.ts
@@ -1,0 +1,54 @@
+"use server"
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+import { AssetType } from "@prisma/client"
+import { revalidatePath } from "next/cache"
+
+export async function updatePortfolioNotes(portfolioId: string, notes: string, goalValue: number | null) {
+  const session = await auth()
+  if (!session?.user?.id) throw new Error("Unauthorized")
+
+  const portfolio = await prisma.portfolio.findFirst({
+    where: { id: portfolioId, userId: session.user.id },
+  })
+  if (!portfolio) throw new Error("Portfolio not found")
+
+  await prisma.portfolio.update({
+    where: { id: portfolioId },
+    data: { notes: notes || null, goalValue: goalValue || null },
+  })
+  revalidatePath("/portfolio")
+}
+
+export async function importPositions(portfolioId: string, rows: { ticker: string; assetType: string; quantity: number; averagePrice: number }[]) {
+  const session = await auth()
+  if (!session?.user?.id) throw new Error("Unauthorized")
+
+  const portfolio = await prisma.portfolio.findFirst({
+    where: { id: portfolioId, userId: session.user.id },
+  })
+  if (!portfolio) throw new Error("Portfolio not found")
+
+  // Upsert each position
+  let created = 0
+  let updated = 0
+  for (const row of rows) {
+    const existing = await prisma.position.findFirst({
+      where: { portfolioId, ticker: row.ticker },
+    })
+    if (existing) {
+      await prisma.position.update({
+        where: { id: existing.id },
+        data: { quantity: row.quantity, averagePrice: row.averagePrice },
+      })
+      updated++
+    } else {
+      await prisma.position.create({
+        data: { portfolioId, ticker: row.ticker, assetType: row.assetType as AssetType, quantity: row.quantity, averagePrice: row.averagePrice },
+      })
+      created++
+    }
+  }
+  revalidatePath("/portfolio")
+  return { created, updated }
+}

--- a/app/(app)/portfolio/page.tsx
+++ b/app/(app)/portfolio/page.tsx
@@ -8,6 +8,8 @@ import { formatCurrency, formatPercent, variationColor } from "@/lib/utils"
 import { AddTransactionDialog } from "@/components/features/portfolio/add-transaction-dialog"
 import { AllocationChart } from "@/components/features/portfolio/allocation-chart"
 import { DividendProjection } from "@/components/features/portfolio/dividend-projection"
+import { PortfolioNotesDialog } from "@/components/features/portfolio/portfolio-notes-dialog"
+import { ImportCsvDialog } from "@/components/features/portfolio/import-csv-dialog"
 import { TrendingUp, DollarSign, BarChart3, PlusCircle } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
@@ -84,7 +86,11 @@ export default async function PortfolioPage() {
           <h1 className="text-xl md:text-2xl font-bold">{portfolio.name}</h1>
           <p className="text-muted-foreground">Acompanhe seus investimentos em tempo real</p>
         </div>
-        <AddTransactionDialog portfolioId={portfolio.id} />
+        <div className="flex gap-2 sm:ml-auto flex-wrap">
+          <AddTransactionDialog portfolioId={portfolio.id} />
+          <ImportCsvDialog portfolioId={portfolio.id} />
+          <PortfolioNotesDialog portfolioId={portfolio.id} initialNotes={portfolio.notes} initialGoal={portfolio.goalValue} />
+        </div>
       </div>
 
       {isEmpty ? (
@@ -128,6 +134,30 @@ export default async function PortfolioPage() {
               )
             })}
           </div>
+
+          {/* Goal progress */}
+          {portfolio.goalValue && portfolio.goalValue > 0 && (
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between text-sm mb-2">
+                  <span className="font-medium">Meta patrimonial</span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {formatCurrency(summary.totalValue)} / {formatCurrency(portfolio.goalValue)}
+                    {" "}({Math.min((summary.totalValue / portfolio.goalValue) * 100, 100).toFixed(1)}%)
+                  </span>
+                </div>
+                <div className="h-3 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full transition-all"
+                    style={{ width: `${Math.min((summary.totalValue / portfolio.goalValue) * 100, 100)}%` }}
+                  />
+                </div>
+                {portfolio.notes && (
+                  <p className="text-xs text-muted-foreground mt-3 whitespace-pre-wrap">{portfolio.notes}</p>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           {/* Charts */}
           <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">

--- a/components/features/portfolio/import-csv-dialog.tsx
+++ b/components/features/portfolio/import-csv-dialog.tsx
@@ -1,0 +1,107 @@
+"use client"
+import { useState } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { importPositions } from "@/app/(app)/portfolio/actions"
+import { Upload, CheckCircle2, AlertCircle } from "lucide-react"
+
+interface Props {
+  portfolioId: string
+}
+
+const EXAMPLE = `PETR4,STOCK,100,37.50
+MXRF11,FII,200,10.20
+VALE3,STOCK,50,68.00`
+
+export function ImportCsvDialog({ portfolioId }: Props) {
+  const [open, setOpen] = useState(false)
+  const [csv, setCsv] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<{ created: number; updated: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleImport() {
+    setError(null)
+    const lines = csv.trim().split("\n").filter(l => l.trim())
+    const rows: { ticker: string; assetType: string; quantity: number; averagePrice: number }[] = []
+
+    for (const line of lines) {
+      const parts = line.split(",").map(s => s.trim())
+      if (parts.length < 4) { setError(`Linha inválida: "${line}"`); return }
+      const [ticker, assetType, qtyStr, priceStr] = parts
+      const quantity = parseFloat(qtyStr)
+      const averagePrice = parseFloat(priceStr)
+      if (!ticker || !assetType || isNaN(quantity) || isNaN(averagePrice)) {
+        setError(`Dados inválidos na linha: "${line}"`); return
+      }
+      rows.push({ ticker: ticker.toUpperCase(), assetType: assetType.toUpperCase(), quantity, averagePrice })
+    }
+
+    if (rows.length === 0) { setError("Nenhuma linha válida encontrada."); return }
+
+    setLoading(true)
+    try {
+      const res = await importPositions(portfolioId, rows)
+      setResult(res)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erro ao importar")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleClose() {
+    setOpen(false)
+    setCsv("")
+    setResult(null)
+    setError(null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={v => { if (!v) handleClose(); else setOpen(true) }}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Upload className="h-4 w-4 mr-2" />
+          Importar CSV
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Importar Posições via CSV</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="text-sm text-muted-foreground space-y-1">
+            <p>Formato: <code className="bg-muted px-1 rounded">TICKER,TIPO,QUANTIDADE,PRECO_MEDIO</code></p>
+            <p>Tipos válidos: <code className="bg-muted px-1 rounded">STOCK</code>, <code className="bg-muted px-1 rounded">FII</code>, <code className="bg-muted px-1 rounded">ETF</code>, <code className="bg-muted px-1 rounded">CRYPTO</code></p>
+          </div>
+          <Textarea
+            placeholder={EXAMPLE}
+            value={csv}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCsv(e.target.value)}
+            rows={8}
+            className="font-mono text-sm"
+          />
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-500">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {error}
+            </div>
+          )}
+          {result && (
+            <div className="flex items-center gap-2 text-sm text-emerald-500">
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              Importado: {result.created} novos, {result.updated} atualizados
+            </div>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={handleClose}>Cancelar</Button>
+            <Button onClick={handleImport} disabled={loading || !csv.trim()}>
+              {loading ? "Importando..." : "Importar"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/features/portfolio/portfolio-notes-dialog.tsx
+++ b/components/features/portfolio/portfolio-notes-dialog.tsx
@@ -1,0 +1,72 @@
+"use client"
+import { useState } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { updatePortfolioNotes } from "@/app/(app)/portfolio/actions"
+import { NotebookPen } from "lucide-react"
+
+interface Props {
+  portfolioId: string
+  initialNotes?: string | null
+  initialGoal?: number | null
+}
+
+export function PortfolioNotesDialog({ portfolioId, initialNotes, initialGoal }: Props) {
+  const [open, setOpen] = useState(false)
+  const [notes, setNotes] = useState(initialNotes ?? "")
+  const [goal, setGoal] = useState(initialGoal ? String(initialGoal) : "")
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    setSaving(true)
+    await updatePortfolioNotes(portfolioId, notes, goal ? parseFloat(goal) : null)
+    setSaving(false)
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <NotebookPen className="h-4 w-4 mr-2" />
+          Notas & Meta
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Notas e Meta Patrimonial</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div>
+            <Label>Meta de patrimônio (R$)</Label>
+            <Input
+              type="number"
+              placeholder="ex: 500000"
+              value={goal}
+              onChange={e => setGoal(e.target.value)}
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label>Notas pessoais</Label>
+            <Textarea
+              placeholder="Estratégia, objetivos, lembretes..."
+              value={notes}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setNotes(e.target.value)}
+              rows={5}
+              className="mt-1"
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? "Salvando..." : "Salvar"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -354,6 +354,8 @@ model Portfolio {
   name        String
   color       String   @default("#3B82F6")
   isDefault   Boolean  @default(false)
+  notes       String?
+  goalValue   Float?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- **Notes & Goal** (#86): set a patrimony goal with progress bar + free-text notes per portfolio
- **CSV Import** (#85/#42): paste or type CSV rows (`TICKER,TYPE,QTY,AVG_PRICE`) to bulk import positions, with upsert logic
- **Textarea** UI component added (used by both dialogs)
- Schema: `notes` (TEXT) and `goalValue` (FLOAT) added to `portfolios` table

Closes #85, #86, #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)