### PR TITLE
feat: portfolio suporta todos os tipos de ativo

### DIFF
--- a/app/(app)/portfolio/page.tsx
+++ b/app/(app)/portfolio/page.tsx
@@ -50,13 +50,20 @@ export default async function PortfolioPage() {
   let summary = { totalValue: 0, totalCost: 0, totalGain: 0, totalGainPercent: 0 }
 
   if (!isEmpty) {
-    const tickers = portfolio.positions.map(p => p.ticker)
-    const quotes = await fetchMultipleQuotes(tickers)
+    // Only fetch market quotes for ticker-based assets
+    const MARKET_TYPES = ["STOCK", "FII", "ETF", "US_STOCK", "CRYPTO"]
+    const marketPositions = portfolio.positions.filter(p => MARKET_TYPES.includes(p.assetType))
+    const manualPositions = portfolio.positions.filter(p => !MARKET_TYPES.includes(p.assetType))
+
+    const tickers = marketPositions.map(p => p.ticker)
+    const quotes = tickers.length > 0 ? await fetchMultipleQuotes(tickers) : []
     const quoteMap = new Map(quotes.map(q => [q.symbol, q]))
 
     positions = portfolio.positions.map(p => {
-      const quote = quoteMap.get(p.ticker)
-      const currentPrice = quote?.regularMarketPrice ?? p.averagePrice
+      const isMarket = MARKET_TYPES.includes(p.assetType)
+      const quote = isMarket ? quoteMap.get(p.ticker) : undefined
+      // For manual assets (fixed income, other): currentPrice = averagePrice (stored value)
+      const currentPrice = isMarket ? (quote?.regularMarketPrice ?? p.averagePrice) : p.averagePrice
       const totalCost = p.quantity * p.averagePrice
       const currentValue = p.quantity * currentPrice
       const gain = currentValue - totalCost
@@ -66,9 +73,11 @@ export default async function PortfolioPage() {
         averagePrice: p.averagePrice, currentPrice, totalCost, currentValue,
         gain, gainPercent, changePercent: quote?.regularMarketChangePercent ?? 0,
         name: quote?.shortName ?? p.ticker, logoUrl: quote?.logourl, weight: 0,
-        dividendsYield: quote?.dividendsYield,
+        dividendsYield: isMarket ? quote?.dividendsYield : undefined,
       }
     })
+    // suppress unused variable warning
+    void manualPositions
 
     const totalValue = positions.reduce((s, p) => s + p.currentValue, 0)
     const totalCost = positions.reduce((s, p) => s + p.totalCost, 0)
@@ -188,37 +197,70 @@ export default async function PortfolioPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {positions.map(p => (
-                    <tr key={p.ticker} className="border-b border-border last:border-0 hover:bg-muted/50 transition-colors">
-                      <td className="p-4">
-                        <Link href={p.assetType === "FII" ? `/fiis/${p.ticker}` : `/acoes/${p.ticker}`} className="flex items-center gap-3 hover:text-primary transition-colors">
-                          {p.logoUrl && (
-                            <div className="w-8 h-8 rounded-full overflow-hidden bg-muted shrink-0">
-                              <Image src={p.logoUrl} alt={p.ticker} width={32} height={32} className="object-cover" />
+                  {positions.map(p => {
+                    const isMarket = ["STOCK", "FII", "ETF", "US_STOCK", "CRYPTO"].includes(p.assetType)
+                    const href = p.assetType === "FII" ? `/fiis/${p.ticker}` : p.assetType === "ETF" ? `/etfs/${p.ticker}` : `/acoes/${p.ticker}`
+                    const assetBadgeColor: Record<string, string> = {
+                      STOCK: "bg-blue-500/10 text-blue-400",
+                      FII: "bg-emerald-500/10 text-emerald-400",
+                      ETF: "bg-violet-500/10 text-violet-400",
+                      US_STOCK: "bg-sky-500/10 text-sky-400",
+                      CRYPTO: "bg-amber-500/10 text-amber-400",
+                      FIXED_INCOME: "bg-rose-500/10 text-rose-400",
+                      OTHER: "bg-zinc-500/10 text-zinc-400",
+                    }
+                    const assetBadgeLabel: Record<string, string> = {
+                      STOCK: "Ação", FII: "FII", ETF: "ETF", US_STOCK: "US",
+                      CRYPTO: "Cripto", FIXED_INCOME: "RF", OTHER: "Outro",
+                    }
+                    return (
+                      <tr key={`${p.ticker}-${p.assetType}`} className="border-b border-border last:border-0 hover:bg-muted/50 transition-colors">
+                        <td className="p-4">
+                          <div className="flex items-center gap-3">
+                            {p.logoUrl ? (
+                              <div className="w-8 h-8 rounded-full overflow-hidden bg-muted shrink-0">
+                                <Image src={p.logoUrl} alt={p.ticker} width={32} height={32} className="object-cover" />
+                              </div>
+                            ) : (
+                              <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded shrink-0 ${assetBadgeColor[p.assetType] ?? "bg-muted text-muted-foreground"}`}>
+                                {assetBadgeLabel[p.assetType] ?? p.assetType}
+                              </span>
+                            )}
+                            <div>
+                              {isMarket ? (
+                                <Link href={href} className="font-semibold hover:text-primary transition-colors">
+                                  {p.ticker}
+                                </Link>
+                              ) : (
+                                <p className="font-semibold text-xs leading-tight max-w-[160px]">{p.ticker}</p>
+                              )}
+                              {isMarket && <p className="text-xs text-muted-foreground truncate max-w-[120px]">{p.name}</p>}
                             </div>
-                          )}
-                          <div>
-                            <p className="font-semibold">{p.ticker}</p>
-                            <p className="text-xs text-muted-foreground truncate max-w-[120px]">{p.name}</p>
                           </div>
-                        </Link>
-                      </td>
-                      <td className="p-4 text-right tabular-nums">{p.quantity.toFixed(p.quantity % 1 === 0 ? 0 : 3)}</td>
-                      <td className="p-4 text-right tabular-nums">{formatCurrency(p.averagePrice)}</td>
-                      <td className="p-4 text-right tabular-nums font-medium">{formatCurrency(p.currentPrice)}</td>
-                      <td className="p-4 text-right"><VariationBadge value={p.changePercent} size="sm" /></td>
-                      <td className="p-4 text-right tabular-nums hidden md:table-cell">{formatCurrency(p.currentValue)}</td>
-                      <td className={`p-4 text-right tabular-nums hidden lg:table-cell ${variationColor(p.gain)}`}>
-                        {p.gain >= 0 ? "+" : ""}{formatCurrency(p.gain)}
-                      </td>
-                      <td className="p-4 text-right hidden lg:table-cell">
-                        <VariationBadge value={p.gainPercent} size="sm" />
-                      </td>
-                      <td className="p-4 text-right tabular-nums text-muted-foreground hidden lg:table-cell">
-                        {p.weight.toFixed(1)}%
-                      </td>
-                    </tr>
-                  ))}
+                        </td>
+                        <td className="p-4 text-right tabular-nums text-xs">
+                          {isMarket ? p.quantity.toFixed(p.quantity % 1 === 0 ? 0 : 3) : "—"}
+                        </td>
+                        <td className="p-4 text-right tabular-nums">{formatCurrency(p.averagePrice)}</td>
+                        <td className="p-4 text-right tabular-nums font-medium">
+                          {isMarket ? formatCurrency(p.currentPrice) : "—"}
+                        </td>
+                        <td className="p-4 text-right">
+                          {isMarket ? <VariationBadge value={p.changePercent} size="sm" /> : <span className="text-xs text-muted-foreground">—</span>}
+                        </td>
+                        <td className="p-4 text-right tabular-nums hidden md:table-cell">{formatCurrency(p.currentValue)}</td>
+                        <td className={`p-4 text-right tabular-nums hidden lg:table-cell ${variationColor(p.gain)}`}>
+                          {p.gain !== 0 ? `${p.gain >= 0 ? "+" : ""}${formatCurrency(p.gain)}` : "—"}
+                        </td>
+                        <td className="p-4 text-right hidden lg:table-cell">
+                          {isMarket ? <VariationBadge value={p.gainPercent} size="sm" /> : <span className="text-xs text-muted-foreground">—</span>}
+                        </td>
+                        <td className="p-4 text-right tabular-nums text-muted-foreground hidden lg:table-cell">
+                          {p.weight.toFixed(1)}%
+                        </td>
+                      </tr>
+                    )
+                  })}
                 </tbody>
               </table>
             </div>

--- a/components/features/portfolio/add-transaction-dialog.tsx
+++ b/components/features/portfolio/add-transaction-dialog.tsx
@@ -12,6 +12,19 @@ interface AddTransactionDialogProps {
   onSuccess?: () => void
 }
 
+// Asset types that don't have market tickers — value is stored directly
+const MANUAL_VALUE_TYPES = ["FIXED_INCOME", "OTHER"]
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  STOCK: "Ação BR",
+  FII: "FII",
+  ETF: "ETF",
+  US_STOCK: "Ação US",
+  CRYPTO: "Cripto",
+  FIXED_INCOME: "Renda Fixa",
+  OTHER: "Outros",
+}
+
 export function AddTransactionDialog({ portfolioId, onSuccess }: AddTransactionDialogProps) {
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -26,16 +39,29 @@ export function AddTransactionDialog({ portfolioId, onSuccess }: AddTransactionD
     notes: "",
   })
 
+  const isManual = MANUAL_VALUE_TYPES.includes(form.assetType)
+
+  function handleAssetTypeChange(v: string) {
+    setForm(f => ({
+      ...f,
+      assetType: v,
+      ticker: "",
+      // For manual types, default qty=1
+      quantity: MANUAL_VALUE_TYPES.includes(v) ? "1" : f.quantity,
+    }))
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     try {
+      const ticker = isManual ? form.ticker : form.ticker.toUpperCase()
       const res = await fetch(`/api/portfolio/${portfolioId}/transactions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...form,
-          ticker: form.ticker.toUpperCase(),
+          ticker,
           quantity: Number(form.quantity),
           price: Number(form.price),
           fees: Number(form.fees),
@@ -45,6 +71,7 @@ export function AddTransactionDialog({ portfolioId, onSuccess }: AddTransactionD
         setOpen(false)
         setForm({ ticker: "", assetType: "STOCK", type: "BUY", date: new Date().toISOString().split("T")[0], quantity: "", price: "", fees: "0", notes: "" })
         onSuccess?.()
+        window.location.reload()
       }
     } finally {
       setLoading(false)
@@ -55,41 +82,41 @@ export function AddTransactionDialog({ portfolioId, onSuccess }: AddTransactionD
     <>
       <Button onClick={() => setOpen(true)} className="gap-2">
         <PlusCircle className="h-4 w-4" />
-        Adicionar operação
+        Adicionar
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Adicionar operação</DialogTitle>
-            <DialogDescription>Registre uma compra, venda ou recebimento de dividendo</DialogDescription>
+            <DialogDescription>Registre uma compra, venda, resgate ou recebimento</DialogDescription>
           </DialogHeader>
 
           <form onSubmit={handleSubmit} className="space-y-4 mt-2">
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <Label>Ticker</Label>
-                <Input
-                  placeholder="Ex: PETR4"
-                  value={form.ticker}
-                  onChange={e => setForm(f => ({ ...f, ticker: e.target.value.toUpperCase() }))}
-                  required
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label>Tipo de ativo</Label>
-                <Select value={form.assetType} onValueChange={v => setForm(f => ({ ...f, assetType: v }))}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="STOCK">Ação BR</SelectItem>
-                    <SelectItem value="FII">FII</SelectItem>
-                    <SelectItem value="ETF">ETF</SelectItem>
-                    <SelectItem value="US_STOCK">Ação US</SelectItem>
-                    <SelectItem value="CRYPTO">Cripto</SelectItem>
-                    <SelectItem value="FIXED_INCOME">Renda Fixa</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+            {/* Asset type first */}
+            <div className="space-y-1.5">
+              <Label>Tipo de ativo</Label>
+              <Select value={form.assetType} onValueChange={handleAssetTypeChange}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {Object.entries(ASSET_TYPE_LABELS).map(([v, l]) => (
+                    <SelectItem key={v} value={v}>{l}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Ticker or name */}
+            <div className="space-y-1.5">
+              <Label>{isManual ? "Nome do ativo" : "Ticker"}</Label>
+              <Input
+                placeholder={isManual
+                  ? (form.assetType === "FIXED_INCOME" ? "Ex: CDB Mercado Pago 110% CDI" : "Ex: Empréstimo Pessoal")
+                  : "Ex: PETR4, BTC, VOO"}
+                value={form.ticker}
+                onChange={e => setForm(f => ({ ...f, ticker: isManual ? e.target.value : e.target.value.toUpperCase() }))}
+                required
+              />
             </div>
 
             <div className="grid grid-cols-2 gap-3">
@@ -98,9 +125,9 @@ export function AddTransactionDialog({ portfolioId, onSuccess }: AddTransactionD
                 <Select value={form.type} onValueChange={v => setForm(f => ({ ...f, type: v }))}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="BUY">Compra</SelectItem>
-                    <SelectItem value="SELL">Venda</SelectItem>
-                    <SelectItem value="DIVIDEND">Dividendo</SelectItem>
+                    <SelectItem value="BUY">Compra / Aplicação</SelectItem>
+                    <SelectItem value="SELL">Venda / Resgate</SelectItem>
+                    <SelectItem value="DIVIDEND">Dividendo / Rendimento</SelectItem>
                     <SelectItem value="JCP">JCP</SelectItem>
                   </SelectContent>
                 </Select>
@@ -112,20 +139,46 @@ export function AddTransactionDialog({ portfolioId, onSuccess }: AddTransactionD
             </div>
 
             <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <Label>Quantidade</Label>
-                <Input type="number" placeholder="0" value={form.quantity} onChange={e => setForm(f => ({ ...f, quantity: e.target.value }))} min="0.001" step="any" required />
-              </div>
-              <div className="space-y-1.5">
-                <Label>Preço unitário (R$)</Label>
-                <Input type="number" placeholder="0.00" value={form.price} onChange={e => setForm(f => ({ ...f, price: e.target.value }))} min="0.001" step="0.01" required />
+              {!isManual && (
+                <div className="space-y-1.5">
+                  <Label>Quantidade</Label>
+                  <Input
+                    type="number"
+                    placeholder="0"
+                    value={form.quantity}
+                    onChange={e => setForm(f => ({ ...f, quantity: e.target.value }))}
+                    min="0.00000001"
+                    step="any"
+                    required
+                  />
+                </div>
+              )}
+              <div className={`space-y-1.5 ${isManual ? "col-span-2" : ""}`}>
+                <Label>{isManual ? "Valor investido / atual (R$)" : "Preço unitário (R$)"}</Label>
+                <Input
+                  type="number"
+                  placeholder="0.00"
+                  value={form.price}
+                  onChange={e => setForm(f => ({ ...f, price: e.target.value }))}
+                  min="0.01"
+                  step="0.01"
+                  required
+                />
               </div>
             </div>
 
-            <div className="space-y-1.5">
-              <Label>Taxas e corretagem (R$)</Label>
-              <Input type="number" placeholder="0.00" value={form.fees} onChange={e => setForm(f => ({ ...f, fees: e.target.value }))} min="0" step="0.01" />
-            </div>
+            {!isManual && (
+              <div className="space-y-1.5">
+                <Label>Taxas e corretagem (R$)</Label>
+                <Input type="number" placeholder="0.00" value={form.fees} onChange={e => setForm(f => ({ ...f, fees: e.target.value }))} min="0" step="0.01" />
+              </div>
+            )}
+
+            {isManual && (
+              <p className="text-xs text-muted-foreground">
+                Para renda fixa e outros, o valor é armazenado diretamente. Atualize manualmente quando o valor mudar.
+              </p>
+            )}
 
             <div className="flex justify-end gap-2 pt-2">
               <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancelar</Button>

--- a/components/features/portfolio/allocation-chart.tsx
+++ b/components/features/portfolio/allocation-chart.tsx
@@ -38,7 +38,7 @@ export function AllocationChart({ positions, totalValue }: Props) {
     typeMap[p.assetType] = (typeMap[p.assetType] ?? 0) + p.currentValue
   })
   const typeData = Object.entries(typeMap).map(([name, value]) => ({
-    name: name === "STOCK" ? "Ações" : name === "FII" ? "FIIs" : name,
+    name: name === "STOCK" ? "Ações BR" : name === "FII" ? "FIIs" : name === "ETF" ? "ETFs" : name === "US_STOCK" ? "Ações US" : name === "CRYPTO" ? "Cripto" : name === "FIXED_INCOME" ? "Renda Fixa" : name === "OTHER" ? "Outros" : name,
     value,
     weight: (value / totalValue) * 100,
   }))

--- a/components/features/portfolio/import-csv-dialog.tsx
+++ b/components/features/portfolio/import-csv-dialog.tsx
@@ -73,7 +73,8 @@ export function ImportCsvDialog({ portfolioId }: Props) {
         <div className="space-y-4 pt-2">
           <div className="text-sm text-muted-foreground space-y-1">
             <p>Formato: <code className="bg-muted px-1 rounded">TICKER,TIPO,QUANTIDADE,PRECO_MEDIO</code></p>
-            <p>Tipos válidos: <code className="bg-muted px-1 rounded">STOCK</code>, <code className="bg-muted px-1 rounded">FII</code>, <code className="bg-muted px-1 rounded">ETF</code>, <code className="bg-muted px-1 rounded">CRYPTO</code></p>
+            <p>Tipos: <code className="bg-muted px-1 rounded">STOCK</code> <code className="bg-muted px-1 rounded">FII</code> <code className="bg-muted px-1 rounded">ETF</code> <code className="bg-muted px-1 rounded">CRYPTO</code> <code className="bg-muted px-1 rounded">FIXED_INCOME</code> <code className="bg-muted px-1 rounded">OTHER</code></p>
+            <p className="text-xs">Para FIXED_INCOME e OTHER: use quantidade=1 e preço=valor atual</p>
           </div>
           <Textarea
             placeholder={EXAMPLE}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,12 +80,13 @@ enum InvestorProfile {
 }
 
 enum AssetType {
-  STOCK    // Ação BR
-  FII      // Fundo Imobiliário
-  ETF      // ETF
-  US_STOCK // Ação US
-  CRYPTO   // Criptomoeda
+  STOCK        // Ação BR
+  FII          // Fundo Imobiliário
+  ETF          // ETF
+  US_STOCK     // Ação US
+  CRYPTO       // Criptomoeda
   FIXED_INCOME // Renda Fixa
+  OTHER        // Outros
 }
 
 enum TransactionType {


### PR DESCRIPTION
## Summary
- **Renda Fixa, Cripto, Outros** agora funcionam no portfolio
- `AddTransactionDialog`: quando tipo é `FIXED_INCOME` ou `OTHER`, exibe campo "Nome do ativo" (livre), sem quantidade, só "Valor investido" — sem buscar cotação no brapi
- Portfolio page: separa ativos de mercado (STOCK/FII/ETF/US_STOCK/CRYPTO) dos manuais; manuais usam preço armazenado como valor atual
- Tabela: badge colorido por tipo, link só para ativos com ticker
- `AllocationChart`: labels PT-BR corretos para todos os tipos
- Enum `OTHER` adicionado ao schema Prisma + DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)