### PR TITLE
feat: editar e excluir lançamentos

### DIFF
--- a/app/api/portfolio/[id]/transactions/[txId]/route.ts
+++ b/app/api/portfolio/[id]/transactions/[txId]/route.ts
@@ -2,6 +2,67 @@ import { NextRequest, NextResponse } from "next/server"
 import { auth } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
 import { applyTransactionToPosition } from "@/lib/portfolio-position"
+import { z } from "zod"
+
+const updateSchema = z.object({
+  ticker: z.string().min(1).max(200).transform(v => v.trim()).optional(),
+  assetType: z.enum(["STOCK", "FII", "ETF", "US_STOCK", "CRYPTO", "FIXED_INCOME", "OTHER"]).optional(),
+  type: z.enum(["BUY", "SELL", "DIVIDEND", "JCP", "AMORTIZATION", "SUBSCRIPTION"]).optional(),
+  date: z.string().optional(),
+  quantity: z.number().positive().optional(),
+  price: z.number().positive().optional(),
+  fees: z.number().min(0).optional(),
+  notes: z.string().optional(),
+})
+
+async function rebuildPositions(portfolioId: string) {
+  await prisma.position.deleteMany({ where: { portfolioId } })
+  const allTx = await prisma.transaction.findMany({
+    where: { portfolioId },
+    orderBy: { date: "asc" },
+  })
+  for (const t of allTx) {
+    await applyTransactionToPosition(portfolioId, t)
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; txId: string }> }
+) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { id, txId } = await params
+
+  const portfolio = await prisma.portfolio.findFirst({ where: { id, userId: session.user.id } })
+  if (!portfolio) return NextResponse.json({ error: "Not found" }, { status: 404 })
+
+  const tx = await prisma.transaction.findFirst({ where: { id: txId, portfolioId: id } })
+  if (!tx) return NextResponse.json({ error: "Transaction not found" }, { status: 404 })
+
+  const body = await req.json()
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const data = parsed.data
+  await prisma.transaction.update({
+    where: { id: txId },
+    data: {
+      ...(data.ticker && { ticker: data.ticker }),
+      ...(data.assetType && { assetType: data.assetType }),
+      ...(data.type && { type: data.type }),
+      ...(data.date && { date: new Date(data.date) }),
+      ...(data.quantity !== undefined && { quantity: data.quantity }),
+      ...(data.price !== undefined && { price: data.price }),
+      ...(data.fees !== undefined && { fees: data.fees }),
+      ...(data.notes !== undefined && { notes: data.notes }),
+    },
+  })
+
+  await rebuildPositions(id)
+  return NextResponse.json({ ok: true })
+}
 
 export async function DELETE(
   req: NextRequest,
@@ -18,18 +79,8 @@ export async function DELETE(
   const tx = await prisma.transaction.findFirst({ where: { id: txId, portfolioId: id } })
   if (!tx) return NextResponse.json({ error: "Transaction not found" }, { status: 404 })
 
-  // Delete the transaction
   await prisma.transaction.delete({ where: { id: txId } })
-
-  // Rebuild all positions from scratch to keep consistency
-  await prisma.position.deleteMany({ where: { portfolioId: id } })
-  const allTx = await prisma.transaction.findMany({
-    where: { portfolioId: id },
-    orderBy: { date: "asc" },
-  })
-  for (const t of allTx) {
-    await applyTransactionToPosition(id, t)
-  }
+  await rebuildPositions(id)
 
   return NextResponse.json({ ok: true })
 }

--- a/components/features/portfolio/transactions-tab.tsx
+++ b/components/features/portfolio/transactions-tab.tsx
@@ -2,9 +2,11 @@
 import { useState, useMemo } from "react"
 import { Card } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { formatCurrency } from "@/lib/utils"
-import { Search, TrendingUp, TrendingDown, DollarSign, RotateCcw, Trash2, AlertTriangle } from "lucide-react"
+import { Search, TrendingUp, TrendingDown, DollarSign, RotateCcw, Trash2, AlertTriangle, Pencil } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
 interface Transaction {
@@ -44,6 +46,8 @@ function TypeIcon({ type }: { type: string }) {
   return <DollarSign className="h-3.5 w-3.5 text-amber-500" />
 }
 
+const VALUE_BASED = ["FIXED_INCOME", "OTHER"]
+
 export function TransactionsTab({ transactions, portfolioId }: TransactionsTabProps) {
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState("ALL")
@@ -52,6 +56,9 @@ export function TransactionsTab({ transactions, portfolioId }: TransactionsTabPr
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [resetting, setResetting] = useState(false)
   const [localTxs, setLocalTxs] = useState(transactions)
+  const [editingTx, setEditingTx] = useState<Transaction | null>(null)
+  const [editForm, setEditForm] = useState<Partial<Transaction>>({})
+  const [saving, setSaving] = useState(false)
 
   const filtered = useMemo(() => {
     return localTxs.filter(tx => {
@@ -84,6 +91,38 @@ export function TransactionsTab({ transactions, portfolioId }: TransactionsTabPr
       }
     } finally {
       setDeletingId(null)
+    }
+  }
+
+  function openEdit(tx: Transaction) {
+    setEditingTx(tx)
+    setEditForm({
+      ticker: tx.ticker,
+      assetType: tx.assetType,
+      type: tx.type,
+      date: new Date(tx.date).toISOString().split("T")[0],
+      quantity: tx.quantity,
+      price: tx.price,
+      fees: tx.fees,
+      notes: tx.notes ?? "",
+    })
+  }
+
+  async function handleSaveEdit() {
+    if (!editingTx) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/portfolio/${portfolioId}/transactions/${editingTx.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(editForm),
+      })
+      if (res.ok) {
+        setEditingTx(null)
+        window.location.reload()
+      }
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -212,14 +251,23 @@ export function TransactionsTab({ transactions, portfolioId }: TransactionsTabPr
                       {tx.fees > 0 ? formatCurrency(tx.fees) : "—"}
                     </td>
                     <td className="p-2 text-right">
-                      <button
-                        onClick={() => handleDelete(tx.id)}
-                        disabled={deletingId === tx.id}
-                        className="p-1 rounded hover:bg-rose-500/10 text-muted-foreground hover:text-rose-500 transition-colors disabled:opacity-50"
-                        title="Excluir lançamento"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => openEdit(tx)}
+                          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                          title="Editar lançamento"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(tx.id)}
+                          disabled={deletingId === tx.id}
+                          className="p-1 rounded hover:bg-rose-500/10 text-muted-foreground hover:text-rose-500 transition-colors disabled:opacity-50"
+                          title="Excluir lançamento"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 )
@@ -246,6 +294,68 @@ export function TransactionsTab({ transactions, portfolioId }: TransactionsTabPr
           </table>
         </div>
       </Card>
+    {/* Edit modal */}
+    <Dialog open={!!editingTx} onOpenChange={v => { if (!v) setEditingTx(null) }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Editar lançamento</DialogTitle>
+        </DialogHeader>
+        {editingTx && (
+          <div className="space-y-4 mt-2">
+            <div className="space-y-1.5">
+              <Label>{VALUE_BASED.includes(editForm.assetType ?? "") ? "Nome do ativo" : "Ticker"}</Label>
+              <Input
+                value={editForm.ticker ?? ""}
+                onChange={e => setEditForm(f => ({ ...f, ticker: e.target.value }))}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Operação</Label>
+                <Select value={editForm.type ?? ""} onValueChange={v => setEditForm(f => ({ ...f, type: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(TYPE_LABELS).map(([v, l]) => <SelectItem key={v} value={v}>{l}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Data</Label>
+                <Input type="date" value={editForm.date as string ?? ""} onChange={e => setEditForm(f => ({ ...f, date: e.target.value }))} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {!VALUE_BASED.includes(editForm.assetType ?? "") && (
+                <div className="space-y-1.5">
+                  <Label>Quantidade</Label>
+                  <Input type="number" step="any" value={editForm.quantity ?? ""} onChange={e => setEditForm(f => ({ ...f, quantity: Number(e.target.value) }))} />
+                </div>
+              )}
+              <div className={`space-y-1.5 ${VALUE_BASED.includes(editForm.assetType ?? "") ? "col-span-2" : ""}`}>
+                <Label>{VALUE_BASED.includes(editForm.assetType ?? "") ? "Valor (R$)" : "Preço unit. (R$)"}</Label>
+                <Input type="number" step="0.01" value={editForm.price ?? ""} onChange={e => setEditForm(f => ({ ...f, price: Number(e.target.value) }))} />
+              </div>
+            </div>
+            {!VALUE_BASED.includes(editForm.assetType ?? "") && (
+              <div className="space-y-1.5">
+                <Label>Taxas (R$)</Label>
+                <Input type="number" step="0.01" value={editForm.fees ?? 0} onChange={e => setEditForm(f => ({ ...f, fees: Number(e.target.value) }))} />
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Label>Obs.</Label>
+              <Input value={editForm.notes ?? ""} onChange={e => setEditForm(f => ({ ...f, notes: e.target.value }))} />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setEditingTx(null)}>Cancelar</Button>
+              <Button onClick={handleSaveEdit} disabled={saving}>
+                {saving ? "Salvando..." : "Salvar"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Botão de lápis (editar) + lixeira (excluir) em cada linha da aba Lançamentos
- Modal de edição pré-preenchido, adapta campos para Renda Fixa/Outros
- `PATCH /api/portfolio/[id]/transactions/[txId]` — atualiza e reconstrói posições
- Botão "Zerar tudo" com dupla confirmação

🤖 Generated with [Claude Code](https://claude.com/claude-code)